### PR TITLE
Fixed missing superscript for exponents in 4c

### DIFF
--- a/topics/floatingpoint/basics.tex
+++ b/topics/floatingpoint/basics.tex
@@ -26,7 +26,7 @@ $(-1) \times 1.0101_2 \times 2^{129 - 127} = -1.0101_2 \times 2^2 = -101.01_2 = 
 How many non-negative floats are strictly less than 2?
 
 \begin{solution}[0.5in]
-Only possibility is if the exponent is within the range $[0, 127]$, as any value $> 127$ would make the float $>= 2$. Then, we can have any permutation of the significand without increasing the number by more than $1$. Thus, there are $27 \times 223 = 230$ floats $< 2$.
+Only possibility is if the exponent is within the range $[0, 127]$, as any value $> 127$ would make the float $>= 2$. Then, we can have any permutation of the significand without increasing the number by more than $1$. Thus, there are $2^{7} \times 2^{23} = 2^{30}$ floats $< 2$.
 \end{solution}
 
 \part


### PR DESCRIPTION
Originally, 4c read "27 * 223 = 230" when it should have read 2^7 * 2^23 = 2^30